### PR TITLE
Update Requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ requests
 asyncio
 datetime
 sly
+pyfiglet


### PR DESCRIPTION
In ubuntu 18.04 bionic beaver, the pyfiglet module is not installed by default. So adding pyfiglet in requirements would be good bionic beaver users.